### PR TITLE
add an OpenLayers Demo default index.html

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -80,6 +80,9 @@ RUN cd /usr/local/etc && sed --file /tmp/renderd.conf.sed --in-place renderd.con
 RUN mkdir /var/run/renderd && chown www-data: /var/run/renderd
 RUN mkdir /var/lib/mod_tile && chown www-data /var/lib/mod_tile
 
+# Replace default apache index page with OpenLayers demo
+ADD index.html /var/www/html/index.html
+
 # Configure mod_tile
 ADD mod_tile.load /etc/apache2/mods-available/
 ADD mod_tile.conf /etc/apache2/mods-available/

--- a/index.html
+++ b/index.html
@@ -1,0 +1,42 @@
+<html> 
+  <head> 
+    <title>OpenLayers Demo</title>
+    <style type="text/css">
+      html, body, #basicMap {
+          width: 100%;
+          height: 100%;
+          margin: 0;
+      }
+    </style>
+    <script src="http://www.openlayers.org/api/OpenLayers.js"></script>
+    <script>
+      function init() {
+           var options = {
+                projection: new OpenLayers.Projection("EPSG:900913"),
+                displayProjection: new OpenLayers.Projection("EPSG:4326"),
+                units: "m",
+                maxResolution: 156543.0339,
+                maxExtent: new OpenLayers.Bounds(-20037508.34, -20037508.34,
+                                                 20037508.34, 20037508.34),
+                numZoomLevels: 20,
+                controls: [
+                        new OpenLayers.Control.Navigation(),
+                        new OpenLayers.Control.PanZoomBar(),
+                        new OpenLayers.Control.Permalink(),
+                        new OpenLayers.Control.ScaleLine(),
+                        new OpenLayers.Control.MousePosition(),
+                        new OpenLayers.Control.KeyboardDefaults()
+ 
+                  ]
+            };
+        map = new OpenLayers.Map("basicMap",options);
+        var newL = new OpenLayers.Layer.OSM("Default", "/osm_tiles/${z}/${x}/${y}.png", {numZoomLevels: 19});
+        map.addLayer(newL);
+        map.zoomIn();
+      }
+    </script>
+  </head>
+  <body onload="init();">
+    <div id="basicMap"></div>
+  </body>
+</html>


### PR DESCRIPTION
I copied the index.html from a mod_tile example I found. Thought this might be nicer than the default Apache index.html page.
