### PR TITLE
Use spatial sql include postgis

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -50,14 +50,14 @@ createdb () {
 
     # Install the Postgis schema
     $asweb psql -d $dbname -f /usr/share/postgresql/9.3/contrib/postgis-2.1/postgis.sql
+    $asweb psql -d $dbname -f /usr/share/postgresql/9.3/contrib/postgis-2.1/spatial_ref_sys.sql
 
     $asweb psql -d $dbname -c 'CREATE EXTENSION HSTORE;'
 
     # Set the correct table ownership
     $asweb psql -d $dbname -c 'ALTER TABLE geometry_columns OWNER TO "www-data"; ALTER TABLE spatial_ref_sys OWNER TO "www-data";'
 
-    # Add the 900913 Spatial Reference System
-    $asweb psql -d $dbname -f /usr/local/share/osm2pgsql/900913.sql
+
 }
 
 import () {


### PR DESCRIPTION
remove     # Add the 900913 Spatial Reference System
    $asweb psql -d $dbname -f /usr/local/share/osm2pgsql/900913.sql

because already include in the spatial_ref_sys.sql

http://wiki.openstreetmap.org/wiki/PostGIS/Installation#Ubuntu_14.04_LTS_2

http://packages.ubuntu.com/fr/trusty-updates/all/postgresql-9.3-postgis-scripts/filelist
