### PR TITLE
correct help.txt command: s/migrate/import/

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -21,7 +21,7 @@ Set up a database saved on an external volume:
   volume that can be used to persist the data:
 
   docker run -v /data/osm-postgresql:/var/lib/postgresql homme/openstreetmap-tiles \
-         initdb startdb createuser createdb migrate
+         initdb startdb createuser createdb import
 
 Import data:
   The following will import the .osm file at `/tmp/import.osm` into the


### PR DESCRIPTION
correct `help.txt` command: `s/migrate/import/`
