### PR TITLE
The "migrate" option is not valid

### DIFF
--- a/help.txt
+++ b/help.txt
@@ -21,7 +21,7 @@ Set up a database saved on an external volume:
   volume that can be used to persist the data:
 
   docker run -v /data/osm-postgresql:/var/lib/postgresql homme/openstreetmap-tiles \
-         initdb startdb createuser createdb migrate
+         initdb startdb createuser createdb
 
 Import data:
   The following will import the .osm file at `/tmp/import.osm` into the


### PR DESCRIPTION
I run this command and it went all fine but at the end it showed the message:
`/usr/local/sbin/run: 127: /usr/local/sbin/run: migrate: not found`
